### PR TITLE
fix: Ship FFmpeg libraries to prevent using those shipped with OBS.

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -42,7 +42,7 @@
     },
     "name": "obs-virtualcam",
     "displayName": "OBS virtual camera",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "author": "Miau Lightouch",
     "website": "https://example.com",
     "email": "miau@example.com",

--- a/src/virtual-source/CMakeLists.txt
+++ b/src/virtual-source/CMakeLists.txt
@@ -3,18 +3,22 @@ cmake_minimum_required(VERSION 3.16...3.26)
 project(obs-virtualsource VERSION ${_version})
 add_library(${PROJECT_NAME} MODULE)
 
-find_package(FFmpeg REQUIRED COMPONENTS avutil swscale)
+find_package(FFmpeg REQUIRED COMPONENTS avutil swscale avcodec avformat swresample)
 target_link_libraries(${PROJECT_NAME} PRIVATE FFmpeg::avutil FFmpeg::swscale)
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(_arch x64)
   set(bit 64bit)
+  add_file(${FFmpeg_avcodec_LIBRARY} ${bit})
+  add_file(${FFmpeg_avformat_LIBRARY} ${bit})
+  add_file(${FFmpeg_swresample_LIBRARY} ${bit})
 else()
   set(_arch x86)
   set(bit 32bit)
-  add_file(${FFmpeg_avutil_LIBRARY} ${bit})
-  add_file(${FFmpeg_swscale_LIBRARY} ${bit})
 endif()
+
+add_file(${FFmpeg_avutil_LIBRARY} ${bit})
+add_file(${FFmpeg_swscale_LIBRARY} ${bit})
 
 # Setup dshowlib
 include_directories("${CMAKE_SOURCE_DIR}/deps/include")


### PR DESCRIPTION
This plugin has a dependency on FFmpeg that is shipped with the OBS installation. In OBS 30.2.0, one of the dependencies, FFmpeg, was updated. Depending on the FFmpeg shipped with OBS is not part of the public API, so it's very easy to cause issues.

Until the FFmpeg libraries when the next OBS public API breaking change occurs, the FFmpeg library will always be shipped along with this plugin.