### PR TITLE
fix: throw error when leaving

### DIFF
--- a/src/virtualcam-output.c
+++ b/src/virtualcam-output.c
@@ -108,6 +108,10 @@ static void virtualcam_deactive(struct virtualcam_data *vcam)
 static void virtualcam_stop(void *data, uint64_t ts)
 {
 	struct virtualcam_data *vcam = (struct virtualcam_data *)data;
+
+	if (os_atomic_load_bool(&vcam->stopping))
+		return;
+
 	os_atomic_set_bool(&vcam->stopping, true);
 
 	obs_log(LOG_INFO, "Virtual output stopping");

--- a/src/virtualcam.cpp
+++ b/src/virtualcam.cpp
@@ -10,14 +10,15 @@ inline void VCam::OnStart(void *, calldata_t * /* params */)
 		dialog->UpdateUIActive(true);
 }
 
-inline void VCam::OnStop(void *data, calldata_t * /* params */)
+inline void VCam::OnStop(void *, calldata_t * /* params */)
 {
-	VCam *vcam = static_cast<VCam *>(data);
-
 	if (dialog)
 		dialog->UpdateUIActive(false);
+}
 
-	// obs_output_set_media(vcam->output, nullptr, nullptr);
+inline void VCam::OnDeactivate(void *data, calldata_t *)
+{
+	VCam *vcam = static_cast<VCam *>(data);
 	vcam->DestroyVirtualCamView();
 }
 
@@ -27,6 +28,9 @@ inline void VCam::OnFrontendEvent(obs_frontend_event event, void *private_data)
 	if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING) {
 		if (vcam->config.autoStart)
 			vcam->StartVirtualCam();
+	} else if (event == OBS_FRONTEND_EVENT_EXIT) {
+		obs_frontend_remove_event_callback(OnFrontendEvent, vcam);
+		vcam->StopVirtualCam();
 	}
 }
 
@@ -78,8 +82,7 @@ void VCam::UpdateVirtualCamOutputSource()
 	if (!virtualCamView)
 		return;
 
-	// FIXME: it may need release
-	obs_source_t *source;
+	OBSSourceAutoRelease source;
 
 	switch (config.type) {
 	case VCamOutputType::InternalOutput:
@@ -98,8 +101,7 @@ void VCam::UpdateVirtualCamOutputSource()
 		source = obs_get_source_by_name(config.scene.c_str());
 		break;
 	case VCamOutputType::SourceOutput:
-		// FIXME: it may need release
-		obs_source_t *s = obs_get_source_by_name(config.source.c_str());
+		OBSSourceAutoRelease s = obs_get_source_by_name(config.source.c_str());
 
 		if (!vCamSourceScene)
 			vCamSourceScene =
@@ -127,17 +129,12 @@ void VCam::UpdateVirtualCamOutputSource()
 			};
 			obs_sceneitem_set_bounds(vCamSourceSceneItem, &size);
 		}
-		// obs_source_release(s);
 		break;
 	}
 
-	// FIXME: it may need release
-	obs_source_t *current = obs_view_get_source(virtualCamView, 0);
+	OBSSourceAutoRelease current = obs_view_get_source(virtualCamView, 0);
 	if (source != current)
 		obs_view_set_source(virtualCamView, 0, source);
-
-	// obs_source_release(source);
-	// obs_source_release(current);
 }
 
 void VCam::Stream()
@@ -195,8 +192,8 @@ void VCam::LoadConfig()
 
 bool VCam::StartVirtualCam()
 {
-	if (output)
-		StopVirtualCam();
+	if (VirtualCamActive())
+		return true;
 
 	obs_data_t *option = obs_data_create();
 	obs_data_set_int(option, "vcamIndex", config.vcamIndex);
@@ -206,6 +203,7 @@ bool VCam::StartVirtualCam()
 	signal_handler_t *handler = obs_output_get_signal_handler(output);
 	signal_handler_connect(handler, "start", OnStart, nullptr);
 	signal_handler_connect(handler, "stop", OnStop, this);
+	signal_handler_connect(handler, "deactivate", OnDeactivate, this);
 	obs_data_release(option);
 
 	if (!virtualCamView)
@@ -230,16 +228,19 @@ bool VCam::StartVirtualCam()
 }
 void VCam::StopVirtualCam()
 {
-	if (!output)
+	if (!VirtualCamActive())
 		return;
 
-	obs_output_stop(output);
 	obs_output_release(output);
 	output = nullptr;
 }
 
 void VCam::DestroyVirtualCamView()
 {
+	if (config.type == VCamOutputType::InternalOutput) {
+		virtualCamVideo = nullptr;
+		return;
+	}
 	obs_view_remove(virtualCamView);
 	obs_view_set_source(virtualCamView, 0, nullptr);
 	virtualCamVideo = nullptr;

--- a/src/virtualcam.cpp
+++ b/src/virtualcam.cpp
@@ -101,7 +101,8 @@ void VCam::UpdateVirtualCamOutputSource()
 		source = obs_get_source_by_name(config.scene.c_str());
 		break;
 	case VCamOutputType::SourceOutput:
-		OBSSourceAutoRelease s = obs_get_source_by_name(config.source.c_str());
+		OBSSourceAutoRelease s =
+			obs_get_source_by_name(config.source.c_str());
 
 		if (!vCamSourceScene)
 			vCamSourceScene =

--- a/src/virtualcam.hpp
+++ b/src/virtualcam.hpp
@@ -2,6 +2,7 @@
 
 #include <QMainWindow>
 #include <QAction>
+#include <obs.hpp>
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 #include "window-vcam.hpp"
@@ -31,6 +32,7 @@ private:
 	void UpdateVirtualCamOutputSource();
 	static inline void OnStart(void *, calldata_t * /* params */);
 	static inline void OnStop(void *, calldata_t * /* params */);
+	static inline void OnDeactivate(void *, calldata_t * /* params */);
 	static inline void OnFrontendEvent(obs_frontend_event event,
 					   void *private_data);
 };


### PR DESCRIPTION
`obs_output_release` also stops the output, which may cause issues if the stop and release actions are too close together.